### PR TITLE
fix inplace operation error

### DIFF
--- a/models/audio_encoder.py
+++ b/models/audio_encoder.py
@@ -481,7 +481,8 @@ class AudioEncoder(BaseFairseqModel):
         x = features
         x_conv = self.pos_conv(x.transpose(1, 2))
         x_conv = x_conv.transpose(1, 2)
-        x += x_conv
+        # x += x_conv
+        x = x + x_conv
         if self.args.use_audio_cls_token:
             x = torch.cat([self.cls_token.repeat(x.shape[0],1,1), x], dim=1)
             if padding_mask != None:
@@ -579,7 +580,8 @@ class AudioEncoder(BaseFairseqModel):
 
         x_conv = self.pos_conv(x.transpose(1, 2))
         x_conv = x_conv.transpose(1, 2)
-        x += x_conv
+        # x += x_conv
+        x = x + x_conv
         # ############################################
         if self.args.use_audio_cls_token:
             x = torch.cat([self.cls_token.repeat(x.shape[0],1,1), x], dim=1)


### PR DESCRIPTION
RuntimeError: one of the variables needed for gradient computation has been modified by an inplace operation: [torch.cuda.FloatTensor [BS, 768, 399]], which is output 0 of AsStridedBackward0, is at version 1; expected version 0 instead. Hint: enable anomaly detection to find the operation that failed to compute its gradient, with torch.autograd.set_detect_anomaly(True).